### PR TITLE
feat: add Makefile that creates media-control-indicator binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+media-control-indicator
+playerctl_systray.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+compile:
+	cp media-control-indicator.py playerctl_systray.py
+	cython3 --embed -o playerctl_systray.c -X language_level=3 playerctl_systray.py
+	PYTHON_VERSION=`ls /usr/include | grep -o 'python[3-9]\+\.[0-9]\+'` ; \
+	gcc -march=native -O2 -pipe -fno-plt -I /usr/include/$$PYTHON_VERSION -o media-control-indicator playerctl_systray.c -l$$PYTHON_VERSION -lpthread -lm -lutil -ldl `pkg-config --cflags --libs gtk+-3.0 appindicator3-0.1 dbus-1 dbus-glib-1`
+	rm playerctl_systray.py playerctl_systray.c


### PR DESCRIPTION
Hey Xaymup 👋🏽

I started making my own implementation of a `playerctl` system tray applet today and I got to this point (functional):

![scrot of playerctl_systray](https://aedrielkylejavier.me/scripts-and-tools/img/playerctl_systray1.png)

I, then, discovered your indicator applet in the AUR and thought it was much better and more complete. So I just started using your implementation of the applet, instead. I made a few changes and would like to send my changes back to your project as a sign of gratitude and appreciation for making this.

I'll be sending 2 PRs:
- **quit_button**: adds a "quit" button to the application so that the applet can be dismissed within itself
- **cython_Makefile**: adds a Makefile that uses `cython --embed` to convert the `.py` file to a `.c` file and then uses `gcc` to compile the applet to a single binary. Theoretically, should also give a performance bump to the applet.